### PR TITLE
Making this permanent on the Qnap

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ Or from docker-compose:
         restart: unless-stopped
         volumes:
           - /etc/logs/event.log:/event.log
+          - /etc/logs/conn.log:/conn.log
+          - /etc/logs/notice.log:/notice.log
         environment:
           - LOG_TYPE=0 
           - TOKEN=XXXXXX
           - USER_KEY=YYYYYYYY
+          - POLL_INTERVAL=10
 
 Adding the following line to the environment stanza will resend the last 10 messages
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,36 @@
 # QNAP-pushover
 This project allows system notifications to be send to pushover. It runs in a docker container.
 
-<img src="notification.png" alt="notification" width="200px">
+<img src="https://raw.githubusercontent.com/vincentcox/QNAP-pushover/master/notification.png" alt="notification" width="200px">
+
+# Docker Hub Installation
+
+From the command line:
+
+    docker run -d --rm -e LOG_TYPE="0" -e TOKEN="XXXXXX" -e USER_KEY="YYYYYYYY" -v /etc/logs/event.log:/event.log mtlott/qnap-pushover qnap-pushover
+
+Or from docker-compose:
+
+    version: "2"
+
+    services:
+      pushover:
+        container_name: qnap-pushover
+        image: mtlott/qnap-pushover:latest
+        restart: unless-stopped
+        volumes:
+          - /etc/logs/event.log:/event.log
+        environment:
+          - LOG_TYPE=0 
+          - TOKEN=XXXXXX
+          - USER_KEY=YYYYYYYY
+
+Adding the following line to the environment stanza will resend the last 10 messages
+
+          - TESTING=True
 
 
-
-# Installation
+# Local Installation
 
 Log via SSH into your NAS (which has docker/Container station installed).
 

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ CURRENT_EVENT_ID = 0 # Init value
 LATEST_EVENT_ID = 0 # Init value
 
 init(TOKEN) # Init Pushover
+Client(USER_KEY).send_message("Starting QNAP Pushover Server...")
 event_log = os.path.join(os.path.curdir, 'event.log') # The event_log needs to be mapped via docker: -v /etc/logs/event.log:event.log
 
 conn = sqlite3.connect(event_log) # The event.log is not a log file, it's a SQL3lite database. QNAP and their logic...

--- a/main.py
+++ b/main.py
@@ -1,10 +1,15 @@
 import sqlite3, os.path, time, os
 from pushover import init, Client
-DB_NAME = "NASLOG_EVENT"
+DB_NAME = ["NASLOG_EVENT", "NASLOG_CONN", "NASLOG_NOTICE"]
+DB_FILENAME = ["event.log", "conn.log", "notice.log"]
 try:
     LOG_TYPE = int(os.environ['LOG_TYPE'])
 except:
     LOG_TYPE = 0 # -1 for all; 0 for error and warning, 1 for error
+try:
+    POLL_INTERVAL = int(os.environ['POLL_INTERVAL'])
+except:
+    POLL_INTERVAL = 10
 try:
     TESTING = bool(os.environ['TESTING'])
 except:
@@ -16,54 +21,62 @@ except:
     print("Tokens need to be set via the docker environment.")
 
 
-CURRENT_EVENT_ID = 0 # Init value
-LATEST_EVENT_ID = 0 # Init value
+CURRENT_EVENT_ID = [0, 0, 0] # Init value
+LATEST_EVENT_ID = [0, 0, 0] # Init value
 
 init(TOKEN) # Init Pushover
 Client(USER_KEY).send_message("Starting QNAP Pushover Server...")
-event_log = os.path.join(os.path.curdir, 'event.log') # The event_log needs to be mapped via docker: -v /etc/logs/event.log:event.log
 
-conn = sqlite3.connect(event_log) # The event.log is not a log file, it's a SQL3lite database. QNAP and their logic...
+log = []
+conn = []
 
-
-# At beginning program get the latest event_id. We don't want pushover to sent the entire event.log DB to our phone. Only the events starting from now.
-cursor = conn.cursor()
-cursor.execute("SELECT * FROM "+DB_NAME+" ORDER BY event_id DESC LIMIT 1;")
-LATEST_EVENT_ID = cursor.fetchone()[0]
-
-if (TESTING == True):
-    LATEST_EVENT_ID = LATEST_EVENT_ID -10
+for k in range(0,2):
+    if os.path.isfile(DB_FILENAME[k]):
+        log[k] = os.path.join(os.path.curdir, DB_FILENAME[k]) # The event_log needs to be mapped via docker: -v /etc/logs/event.log:event.log
+        conn[k] = sqlite3.connect(log[k]) # The event.log is not a log file, it's a SQL3lite database. QNAP and their logic...
+        # At beginning program get the latest event_id. We don't want pushover to sent the entire event.log DB to our phone. Only the events starting from now.
+        cursor = conn[k].cursor()
+        cursor.execute("SELECT * FROM "+DB_NAME[k]+" ORDER BY event_id DESC LIMIT 1;")
+        LATEST_EVENT_ID[k] = cursor.fetchone()[0]
+        if (TESTING == True):
+            LATEST_EVENT_ID[k] = LATEST_EVENT_ID[k] -10
+    else:
+        conn[k] = None
 
 while True:
-    # Check for new event_id's
-    cursor = conn.cursor()
-    cursor.execute("SELECT * FROM "+DB_NAME+" ORDER BY event_id DESC LIMIT 1;")
-    CURRENT_EVENT_ID = cursor.fetchone()[0]
-
-    if (CURRENT_EVENT_ID != LATEST_EVENT_ID):
-        print("New events detected")
-        New_event_count = CURRENT_EVENT_ID - LATEST_EVENT_ID
-        # for testing:
-
-        error = False
-        for i in range(New_event_count):
-            # print(i)
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT * FROM " + DB_NAME + " where event_id="+str(LATEST_EVENT_ID-i)+";")
-            event = cursor.fetchone()
-            if event[1] > LOG_TYPE:
-                # print(event[7])
-                try:
-                    Client(USER_KEY).send_message(event[2]+" - "+event[3]+": "+event[7], title="NAS notification")
-                except:
-                    error= True
-        if (error == True):
-            print("There was an error while sending the latest batch. Retrying next round.")
-            CURRENT_EVENT_ID = LATEST_EVENT_ID
+    for j in range(0,2):
+        # Check for new event_id's
+        if conn[j] is None:
+            pass
         else:
-            LATEST_EVENT_ID = CURRENT_EVENT_ID
-    else:
-        print("No new events detected")
+            cursor = conn[j].cursor()
+            cursor.execute("SELECT * FROM "+DB_NAME[j]+" ORDER BY event_id DESC LIMIT 1;")
+            CURRENT_EVENT_ID[j] = cursor.fetchone()[0]
 
-    time.sleep(10)
+            if (CURRENT_EVENT_ID[j] != LATEST_EVENT_ID[j]):
+                print("New events detected on "+DB_NAME[j])
+                New_event_count = CURRENT_EVENT_ID[j] - LATEST_EVENT_ID[j]
+                # for testing:
+
+                error = False
+                for i in range(New_event_count):
+                    # print(i)
+                    cursor = conn[j].cursor()
+                    cursor.execute(
+                        "SELECT * FROM " + DB_NAME[j] + " where event_id="+str(LATEST_EVENT_ID[j]-i)+";")
+                    event = cursor.fetchone()
+                    if event[1] > LOG_TYPE:
+                        # print(event[7])
+                        try:
+                            Client(USER_KEY).send_message(event[2]+" - "+event[3]+": "+event[7], title="NAS notification")
+                        except:
+                            error= True
+                if (error == True):
+                    print("There was an error while sending the latest batch. Retrying next round.")
+                    CURRENT_EVENT_ID[j] = LATEST_EVENT_ID[j]
+                else:
+                    LATEST_EVENT_ID[j] = CURRENT_EVENT_ID[j]
+            else:
+                print("No new events detected")
+
+    time.sleep(POLL_INTERVAL)

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import sqlite3, os.path, time, os
 from pushover import init, Client
 DB_NAME = ["NASLOG_EVENT", "NASLOG_CONN", "NASLOG_NOTICE"]
 DB_FILENAME = ["event.log", "conn.log", "notice.log"]
+event_id=["event_id", "conn_id", "id"]
 try:
     LOG_TYPE = int(os.environ['LOG_TYPE'])
 except:
@@ -36,7 +37,7 @@ for k in range(0,2):
         conn[k] = sqlite3.connect(log[k]) # The event.log is not a log file, it's a SQL3lite database. QNAP and their logic...
         # At beginning program get the latest event_id. We don't want pushover to sent the entire event.log DB to our phone. Only the events starting from now.
         cursor = conn[k].cursor()
-        cursor.execute("SELECT * FROM "+DB_NAME[k]+" ORDER BY event_id DESC LIMIT 1;")
+        cursor.execute("SELECT * FROM "+DB_NAME[k]+" ORDER BY "+event_id[k]+" DESC LIMIT 1;")
         LATEST_EVENT_ID[k] = cursor.fetchone()[0]
         if (TESTING == True):
             LATEST_EVENT_ID[k] = LATEST_EVENT_ID[k] -10
@@ -50,7 +51,7 @@ while True:
             pass
         else:
             cursor = conn[j].cursor()
-            cursor.execute("SELECT * FROM "+DB_NAME[j]+" ORDER BY event_id DESC LIMIT 1;")
+            cursor.execute("SELECT * FROM "+DB_NAME[j]+" ORDER BY "+event_id[k]+" DESC LIMIT 1;")
             CURRENT_EVENT_ID[j] = cursor.fetchone()[0]
 
             if (CURRENT_EVENT_ID[j] != LATEST_EVENT_ID[j]):
@@ -63,7 +64,7 @@ while True:
                     # print(i)
                     cursor = conn[j].cursor()
                     cursor.execute(
-                        "SELECT * FROM " + DB_NAME[j] + " where event_id="+str(LATEST_EVENT_ID[j]-i)+";")
+                        "SELECT * FROM " + DB_NAME[j] + " where "+event_id[k]+"="+str(LATEST_EVENT_ID[j]-i)+";")
                     event = cursor.fetchone()
                     if event[1] > LOG_TYPE:
                         # print(event[7])

--- a/main.py
+++ b/main.py
@@ -27,8 +27,8 @@ LATEST_EVENT_ID = [0, 0, 0] # Init value
 init(TOKEN) # Init Pushover
 Client(USER_KEY).send_message("Starting QNAP Pushover Server...")
 
-log = []
-conn = []
+log = [None, None, None]
+conn = [None, None, None]
 
 for k in range(0,2):
     if os.path.isfile(DB_FILENAME[k]):

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ while True:
             pass
         else:
             cursor = conn[j].cursor()
-            cursor.execute("SELECT * FROM "+DB_NAME[j]+" ORDER BY "+event_id[k]+" DESC LIMIT 1;")
+            cursor.execute("SELECT * FROM "+DB_NAME[j]+" ORDER BY "+event_id[j]+" DESC LIMIT 1;")
             CURRENT_EVENT_ID[j] = cursor.fetchone()[0]
 
             if (CURRENT_EVENT_ID[j] != LATEST_EVENT_ID[j]):
@@ -64,7 +64,7 @@ while True:
                     # print(i)
                     cursor = conn[j].cursor()
                     cursor.execute(
-                        "SELECT * FROM " + DB_NAME[j] + " where "+event_id[k]+"="+str(LATEST_EVENT_ID[j]-i)+";")
+                        "SELECT * FROM " + DB_NAME[j] + " where "+event_id[j]+"="+str(LATEST_EVENT_ID[j]-i)+";")
                     event = cursor.fetchone()
                     if event[1] > LOG_TYPE:
                         # print(event[7])


### PR DESCRIPTION
Team,

I to be honest I have gotten lazy in the last couple of years and I leverage the ContainerStation GUI now 99% of the time.  I love your work because I've been on Qnaps since 2006 and PushOver since 2016.  That said if I just use the run command the docker dies on a reboot or container station restart.  I can't use the GUI to create the container because I can't build and exposed share for and the script needs access to: 
- /etc/logs/event.log:/event.log
- /etc/logs/conn.log:/conn.log
- /etc/logs/notice.log:/notice.log

So I started playing with the compose instructions but I think there needs to be more in the readme for those that are not versed in or have forgotten (my case) everything they knew about compose :-)

So if put your compose tex in a docker-compose.yml file and run docker-compose create it builds but when I try to start it freaks because (I believe) there is no network defined in the compose file.

It would be a fantastic contribution (I'm willing to help test or whatever I can) if you can help everyone come up with a clean way of making the docker run permanently on ContainerStation.

Thanks again for the great work!